### PR TITLE
rules/cpp: demonstrate that depfiles are properly parsed and available in the ActionCache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheAwareAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheAwareAction.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.actions;
 
+import com.google.devtools.build.lib.actions.cache.ActionCache;
+
 /**
  * Actions that require special handling by the ActionCache. TODO(b/159326450): Remove this
  * interface once Starlark supports mandatory inputs specification.
@@ -21,4 +23,7 @@ public interface ActionCacheAwareAction {
 
   /** By default, the action cache only stores non-mandatory inputs' execPaths. */
   boolean storeInputsExecPathsInActionCache();
+
+  // POC-only: We abuse this interface for a prototype.
+  void filterIncludeSrcs(ActionCache.Entry entry);
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.cache.ActionCache;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.CommandLines.CommandLineLimits;
@@ -143,6 +144,11 @@ public final class StarlarkAction extends SpawnAction implements ActionCacheAwar
   @Override
   public boolean isShareable() {
     return !unusedInputsList.isPresent();
+  }
+
+  @Override
+  public void filterIncludeSrcs(ActionCache.Entry entry) {
+    // no-op
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaAction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaAction.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.NinjaMysteryArtifact;
 import com.google.devtools.build.lib.actions.ArtifactResolver;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.cache.ActionCache;
 import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.CommandLines.CommandLineLimits;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
@@ -250,5 +251,10 @@ public class NinjaAction extends SpawnAction implements ActionCacheAwareAction {
   @Override
   public boolean storeInputsExecPathsInActionCache() {
     return discoversInputs();
+  }
+
+  @Override
+  public void filterIncludeSrcs(ActionCache.Entry entry) {
+    // no-op
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
@@ -74,7 +74,7 @@ public final class CcCompilationContext implements CcCompilationContextApi<Artif
   private final CommandLineCcCompilationContext commandLineCcCompilationContext;
 
   private final NestedSet<PathFragment> looseHdrsDirs;
-  private final NestedSet<Artifact> declaredIncludeSrcs;
+  private NestedSet<Artifact> declaredIncludeSrcs;  // POC-only: Has to differ for computeKey()
 
   /** Module maps from direct dependencies. */
   private final ImmutableList<Artifact> directModuleMaps;
@@ -152,6 +152,15 @@ public final class CcCompilationContext implements CcCompilationContextApi<Artif
   @Override
   public boolean isImmutable() {
     return true; // immutable and Starlark-hashable
+  }
+
+  public void filterIncludeSrcs(Collection<String> files) {
+      declaredIncludeSrcs =
+          NestedSetBuilder.wrap(declaredIncludeSrcs.getOrder(),
+                                declaredIncludeSrcs.toList()
+                                    .stream()
+                                    .filter(p->files.contains(p.prettyPrint()))
+                                    .collect(ImmutableSet.toImmutableSet()));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.AbstractAction;
+import com.google.devtools.build.lib.actions.ActionCacheAwareAction;
 import com.google.devtools.build.lib.actions.ActionContinuationOrResult;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
@@ -41,6 +42,7 @@ import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactResolver;
+import com.google.devtools.build.lib.actions.cache.ActionCache;
 import com.google.devtools.build.lib.actions.CommandAction;
 import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
@@ -118,7 +120,7 @@ import net.starlark.java.eval.StarlarkList;
 
 /** Action that represents some kind of C++ compilation step. */
 @ThreadCompatible
-public class CppCompileAction extends AbstractAction implements IncludeScannable, CommandAction {
+public class CppCompileAction extends AbstractAction implements ActionCacheAwareAction, IncludeScannable, CommandAction {
 
   private static final PathFragment BUILD_PATH_FRAGMENT = PathFragment.create("BUILD");
 
@@ -354,6 +356,18 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   @Override
   public NestedSet<Artifact> getMandatoryInputs() {
     return mandatoryInputs;
+  }
+
+  @Override
+  public boolean storeInputsExecPathsInActionCache() {
+    return true; // TODO What shall the default be? (Irrelevant for POC)
+  }
+
+  @Override
+  public void filterIncludeSrcs(ActionCache.Entry entry) {
+    if (entry != null) {
+      ccCompilationContext.filterIncludeSrcs(entry.getPaths());
+    }
   }
 
   @Override


### PR DESCRIPTION
As a POC, show that all required information from depfiles is available.
Use a brute-force approach to retroactively filter declaredIncludeSrcs
for the actually required include sources.

As a result, actions whose inputs haven't changed but whose declared
files have changed to now contain unused files are not executed again.

The underlying problem here is that the ActionCache does not exist or is
not used when CppCompileContexts and CppCompileActions are initialized.
These, originally mostly immutable, instances are based solely on the
view that the analysis phase gets from inspecting the project files. The
analysis phase does not take into account the information gathered - and
stored - during the previous execution phases.

This change was only tested using the following command. Other test
cases may have been broken.

  bazelisk test //src/test/shell/integration:cpp_test